### PR TITLE
Fix headless plotting backend for analysis scripts

### DIFF
--- a/data/combine_gaussians.py
+++ b/data/combine_gaussians.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 import numpy as np
+import matplotlib
+
+matplotlib.use('Agg')  # Ensure plotting works on headless systems
+
 import matplotlib.pyplot as plt
 from scipy.stats import norm
 import pandas as pd

--- a/data/stats_combine_gaussians.py
+++ b/data/stats_combine_gaussians.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 import numpy as np
+import matplotlib
+
+matplotlib.use('Agg')  # Ensure plots render without a display server
+
 import matplotlib.pyplot as plt
 from scipy.stats import norm
 import pandas as pd
@@ -251,9 +255,12 @@ def create_corrected_mdf_combination(
             ax4.set_xlim(feh_range)
         
         plt.tight_layout()
-        plt.savefig(output_file.replace('.dat', '_comparison.png'), 
-                   dpi=300, bbox_inches='tight')
-        plt.show()
+        plt.savefig(
+            output_file.replace('.dat', '_comparison.png'),
+            dpi=300,
+            bbox_inches='tight',
+        )
+        plt.close(fig)
     
     return x, combined_mdf
 

--- a/uncertainty_analysis.py
+++ b/uncertainty_analysis.py
@@ -10,6 +10,10 @@ import os
 import sys
 import numpy as np
 import pandas as pd
+import matplotlib
+
+matplotlib.use('Agg')  # Use non-interactive backend suitable for clusters
+
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from scipy.stats import gaussian_kde, bootstrap, percentileofscore

--- a/unvertainty_analysis.py
+++ b/unvertainty_analysis.py
@@ -9,13 +9,15 @@ Authors: N Miller, based on analysis framework
 
 
 import numpy as np
-from scipy.stats import gaussian_kde
 
 import os
 import sys
-import numpy as np
 import re, glob
 import pandas as pd
+import matplotlib
+
+matplotlib.use('Agg')  # Use non-interactive backend for headless environments
+
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 from itertools import cycle


### PR DESCRIPTION
## Summary
- ensure plotting scripts select the Agg backend so they can run on headless clusters
- avoid blocking GUI calls in the gaussian statistics helper by closing figures after saving

## Testing
- python -m compileall uncertainty_analysis.py unvertainty_analysis.py data/combine_gaussians.py data/stats_combine_gaussians.py

------
https://chatgpt.com/codex/tasks/task_e_68d38855ea648321baf9b75ebff43b13